### PR TITLE
Add buffer to image cleaning script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ gray: #9DB7C1
 I created helper scrips to compress images and create thumbnails. I use these when uploading new photos:
 
 ```sh
-# Compress images.
-pnpm clean-images --max_kb 2100 --no-dry-run
+# Compress images. Add a small buffer so borderline files are skipped.
+pnpm clean-images --max_kb 2100 --buffer_kb 100 --no-dry-run
 
 # Update Typescript objects.
 pnpm generate:assets
@@ -56,4 +56,4 @@ Then you can go to the [admin page](http://localhost:3000/admin/photos) and set 
 ### To Do
 
 - [ ] Add a whitelist of blog images that don't need to be compressed. (ie. `docs/media/blog/images/mintlify-feature/mintlify-founder-mode-blog-post.jpeg`)
-- [ ] Add a buffer to the clean image script so that we don't repeatedly compress the same images that are borderline.
+- [x] Add a buffer to the clean image script so that we don't repeatedly compress the same images that are borderline.

--- a/scripts/clean_assets.py
+++ b/scripts/clean_assets.py
@@ -5,6 +5,12 @@ import argparse
 parser = argparse.ArgumentParser(description="Detect and fix images that are too large")
 parser.add_argument("--max_kb", type=int, default=3500, help="max KB for image")
 parser.add_argument(
+    "--buffer_kb",
+    type=int,
+    default=100,
+    help="size buffer in KB to skip recompressing borderline images",
+)
+parser.add_argument(
     "--dry-run",
     type=bool,
     default=True,
@@ -56,8 +62,8 @@ def main():
         # Get the size of the existing thumbnail
         storage_size = os.path.getsize(file)
 
-        # If the thumbnail is over the specified limit, regenerate it.
-        if storage_size > args.max_kb * 1024:
+        # If the image is significantly over the specified limit, regenerate it.
+        if storage_size > (args.max_kb + args.buffer_kb) * 1024:
             num_oversized_images += 1
         else:
             num_ok_images += 1
@@ -94,7 +100,7 @@ def main():
         f"""
 Asset Cleaning Complete:
     ✅ Completed: {num_images_fixed} resizes
-    🛠️ Oversized: {num_oversized_images} over {bytes_to_human_readable(args.max_kb * 1024)}
+    🛠️ Oversized: {num_oversized_images} over {bytes_to_human_readable((args.max_kb + args.buffer_kb) * 1024)}
     ⏭️ Skipped: {num_ok_images} existing
     📷 Total: {num_photos} photos
     🗃️ Saved: {bytes_to_human_readable(abs(total_bytes_saved))}"""


### PR DESCRIPTION
## Summary
- add `--buffer_kb` option to `clean_assets.py`
- update output to reflect new buffer
- document buffer usage in README
- mark TODO item as done

## Testing
- `pnpm test`