### PR TITLE
Add AI Engineer World's Fair 2025 keynote post

### DIFF
--- a/src/data/blog/2025-06-04-aiewf-sf-keynote.md
+++ b/src/data/blog/2025-06-04-aiewf-sf-keynote.md
@@ -1,0 +1,17 @@
+---
+title: "AI Engineer World's Fair 2025: Windsurf Keynote before Jensen and Greg"
+author: "Kevin Hou"
+date: 2025-06-04 10:00:00
+description: "I delivered the keynote at AI Engineer World's Fair 2025 in San Francisco right before Jensen Huang and Greg Brockman."
+image: "https://khou22.github.io/media/blog/images/ai-engineer-worlds-fair-2025/stage-shot.jpg"
+tags: [coding]
+featured: false
+---
+
+The full talk can be found on YouTube: [AI Engineer World's Fair 2025 Keynote](https://www.youtube.com/live/z4zXicOAF28?t=27266&si=EHxX8ZEj1hbJBKT1).
+
+[![AI Engineer World's Fair 2025 Kevin Hou keynote stage](https://khou22.github.io/media/blog/images/ai-engineer-worlds-fair-2025/stage-shot.jpg)](https://www.youtube.com/live/z4zXicOAF28?t=27266&si=EHxX8ZEj1hbJBKT1)
+
+Had the honor of sharing the Windsurf vision during the opening keynote at AI Engineer World's Fair San Francisco. I spoke right before Jensen Huang and Greg Brockman about how agents are transforming the way developers build software.
+
+![windsurf stickers at AIEWF 2025](https://khou22.github.io/media/blog/images/ai-engineer-worlds-fair-2025/windsurf-stickers.jpg)

--- a/src/data/blog/2025-06-04-aiewf-sf-keynote.md
+++ b/src/data/blog/2025-06-04-aiewf-sf-keynote.md
@@ -8,9 +8,9 @@ tags: [coding]
 featured: false
 ---
 
-The full talk can be found on YouTube: [AI Engineer World's Fair 2025 Keynote](https://www.youtube.com/live/z4zXicOAF28?t=27266&si=EHxX8ZEj1hbJBKT1).
+The full talk can be found on YouTube: [AI Engineer World's Fair: Windsurf everywhere, doing everything, all at once - Kevin Hou, Windsurf](https://www.youtube.com/watch?v=JVuNPL5QO8Q).
 
-[![AI Engineer World's Fair 2025 Kevin Hou keynote stage](https://khou22.github.io/media/blog/images/ai-engineer-worlds-fair-2025/stage-shot.jpg)](https://www.youtube.com/live/z4zXicOAF28?t=27266&si=EHxX8ZEj1hbJBKT1)
+[![AI Engineer World's Fair 2025 Kevin Hou keynote stage](https://khou22.github.io/media/blog/images/ai-engineer-worlds-fair-2025/stage-shot.jpg)](https://www.youtube.com/watch?v=JVuNPL5QO8Q)
 
 Had the honor of sharing the Windsurf vision during the opening keynote at AI Engineer World's Fair San Francisco. I spoke right before Jensen Huang and Greg Brockman about how agents are transforming the way developers build software.
 


### PR DESCRIPTION
## Summary
- add a short post about the AI Engineer World's Fair 2025 keynote

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm prettier`

------
https://chatgpt.com/codex/tasks/task_e_68433a8c1c38832189c0ad31bca9db70