### PR TITLE
Ensure homepage preview card image is first in DOM

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,10 +14,20 @@ import { ParallaxHoverCard } from "@/components/atoms/ParallaxHoverCard/Parallax
 import { PhotoImage } from "@/components/atoms/PhotoImage/PhotoImage";
 import { SocialLinks } from "@/components/molecules/SocialLinks/SocialLinks";
 import { BioSection } from "@/components/organisms/BioSection/BioSection";
+import { siteMetadata } from "@/constants/siteMetadata";
 
 const HomePage = async () => {
   return (
     <main className="overflow-x-hidden">
+      {/* Hidden preview image so link unfurls fall back to the site card. */}
+      <img
+        src={siteMetadata.previewCard.url}
+        alt={siteMetadata.title}
+        width={siteMetadata.previewCard.width}
+        height={siteMetadata.previewCard.height}
+        className="sr-only"
+        loading="lazy"
+      />
       <ParallaxCover />
 
       {/* Gradient transition to the page content. */}


### PR DESCRIPTION
## Summary
- hide preview card image at top of homepage so link unfurls fall back to site card instead of cloud PNG

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689f67d8257c8321adf006e54bfed7dc