### PR TITLE
Add password generator tool

### DIFF
--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -26,6 +26,11 @@ const ToolsPage = () => {
             RGB to OKLCH Converter
           </CustomLink>
         </li>
+        <li>
+          <CustomLink href={PAGES.TOOLS.PASSWORD_GENERATOR}>
+            Password Generator
+          </CustomLink>
+        </li>
       </ul>
     </PageWrapper>
   );

--- a/src/app/tools/password-generator/PasswordGenerator.tsx
+++ b/src/app/tools/password-generator/PasswordGenerator.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const LOWERCASE = "abcdefghijklmnopqrstuvwxyz";
+const UPPERCASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const NUMBERS = "0123456789";
+const SYMBOLS = "!@#$%^&*()_+[]{}|;:,.<>?/";
+const PASSWORD_LENGTH = 16;
+
+export const PasswordGenerator = () => {
+  const [includeLetters, setIncludeLetters] = useState(true);
+  const [includeNumbers, setIncludeNumbers] = useState(true);
+  const [includeSymbols, setIncludeSymbols] = useState(true);
+  const [mixedCase, setMixedCase] = useState(true);
+  const [password, setPassword] = useState("");
+
+  const generatePassword = useCallback(() => {
+    let chars = "";
+    if (includeLetters) {
+      chars += mixedCase ? LOWERCASE + UPPERCASE : LOWERCASE;
+    }
+    if (includeNumbers) {
+      chars += NUMBERS;
+    }
+    if (includeSymbols) {
+      chars += SYMBOLS;
+    }
+    if (!chars) {
+      setPassword("");
+      return;
+    }
+    let raw = "";
+    for (let i = 0; i < PASSWORD_LENGTH; i++) {
+      raw += chars[Math.floor(Math.random() * chars.length)];
+    }
+    const withDashes = raw.match(/.{1,4}/g)?.join("-") || raw;
+    setPassword(withDashes);
+  }, [includeLetters, includeNumbers, includeSymbols, mixedCase]);
+
+  useEffect(() => {
+    generatePassword();
+  }, [generatePassword]);
+
+  const copyPassword = () => {
+    if (!password) return;
+    navigator.clipboard.writeText(password);
+    toast("Copied to clipboard");
+  };
+
+  return (
+    <div className="mt-4 flex flex-col gap-4">
+      <div className="flex flex-wrap gap-4">
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="letters"
+            checked={includeLetters}
+            onCheckedChange={(v) => setIncludeLetters(!!v)}
+          />
+          <Label htmlFor="letters">Letters</Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="numbers"
+            checked={includeNumbers}
+            onCheckedChange={(v) => setIncludeNumbers(!!v)}
+          />
+          <Label htmlFor="numbers">Numbers</Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="symbols"
+            checked={includeSymbols}
+            onCheckedChange={(v) => setIncludeSymbols(!!v)}
+          />
+          <Label htmlFor="symbols">Symbols</Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="mixed"
+            checked={mixedCase}
+            onCheckedChange={(v) => setMixedCase(!!v)}
+            disabled={!includeLetters}
+          />
+          <Label htmlFor="mixed">Mixed Case</Label>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Input value={password} readOnly className="min-w-[250px] flex-1" />
+        <Button onClick={copyPassword} type="button">
+          Copy
+        </Button>
+        <Button onClick={generatePassword} type="button">
+          Regenerate
+        </Button>
+      </div>
+    </div>
+  );
+};
+

--- a/src/app/tools/password-generator/page.tsx
+++ b/src/app/tools/password-generator/page.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from "next";
+import { PasswordGenerator } from "./PasswordGenerator";
+import { PageWrapper } from "@/components/organisms/PageWrapper/PageWrapper";
+
+export const metadata: Metadata = {
+  title: "Password Generator | Kevin Hou",
+};
+
+const PasswordGeneratorPage = () => {
+  return (
+    <PageWrapper maxWidth="wide">
+      <h1 className="mb-4 text-center leading-loose">Password Generator</h1>
+      <PasswordGenerator />
+    </PageWrapper>
+  );
+};
+
+export default PasswordGeneratorPage;
+

--- a/src/utils/pages.ts
+++ b/src/utils/pages.ts
@@ -49,6 +49,7 @@ export const PAGES = {
     PHOTO_BLUR: "/tools/photo-blur",
     TWEET_PREVIEW: "/tools/tweet-preview",
     RGB_TO_OKLCH: "/tools/rgb-to-oklch",
+    PASSWORD_GENERATOR: "/tools/password-generator",
   },
   ADMIN: {
     PHOTOGRAPHY: "/admin/photos",


### PR DESCRIPTION
## Summary
- add password generator page and client component
- link new password generator from tools index and navigation constants

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8ad1f331c8321b937fc040895d53f